### PR TITLE
チャット画面配送情報の表示機能

### DIFF
--- a/app/assets/stylesheets/comment.css
+++ b/app/assets/stylesheets/comment.css
@@ -188,15 +188,21 @@
   margin: 20px auto;
 }
 
-.buyer-info-inner p:hover {
-  background-color: rgb(207, 207, 207);
-}
 
 .buyer-info-inner {
   margin: 0 auto;
-  width: 200px;
+  width: 250px;
+}
+
+.buyer-info-inner span {
+  font-size: 12px;
+  width: 100px;
 }
 
 .buyer-info-inner li {
   text-align: left;
+}
+
+.hidden {
+  display: none;
 }

--- a/app/javascript/delivery_preview.js
+++ b/app/javascript/delivery_preview.js
@@ -1,0 +1,24 @@
+window.addEventListener("load", () => {
+
+  const deliveryPreview = document.getElementById("delivery-preview");
+  const deliveryList = document.getElementById("delivery-list");
+
+  deliveryPreview.addEventListener("mouseover", () => {
+    deliveryPreview.setAttribute("style", "background-color: rgb(207, 207, 207);")
+  })
+
+  deliveryPreview.addEventListener("mouseout", () => {
+    deliveryPreview.removeAttribute("style", "background-color: rgb(207, 207, 207);")
+  })
+
+  deliveryPreview.addEventListener("click", () => {
+    
+    if (deliveryList.getAttribute("style") == "display: block;") {
+      deliveryList.removeAttribute("style", "display: block;")
+    } else {
+      deliveryList.setAttribute("style", "display: block;")
+    }
+    
+  })
+
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ require("channels")
 require("../card")
 require("../price")
 require("../preview")
+require("../delivery_preview")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/views/deals/show.html.erb
+++ b/app/views/deals/show.html.erb
@@ -26,8 +26,9 @@
 <% if current_seller == @deal.seller %>
   <div class="buyer-info-contents">
     <div class="buyer-info-inner">
-      <p>購入者情報を表示</p>
-      <ul class="buyer-info-lists">
+      <p id="delivery-preview">購入者情報を表示</p>
+      <span>※クリックすると購入者情報が表示されます</span>
+      <ul class="buyer-info-lists hidden", id="delivery-list">
         <li>購入者氏名：<%= @deal.buyer.nickname %></li>
         <li>郵便番号：<%= @transaction.postal_code %></li>
         <li>都道府県：<%= @transaction.shipping_area.name %></li>


### PR DESCRIPTION
# what 
チャット画面に出品者のみ見れる配送情報の表示機能

# why
出品者が配送先を確認できるように。
個人情報なので、晒しっぱなしはまずいと思いjsで表示・非表示を切り替え可能に。